### PR TITLE
added simple argv checker to set port

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,11 +30,12 @@ if __name__ == '__main__':  # Script executed directly?
     #define port number via cmd-line arguments
     #checks for -p as first argument, and presence of a number as the second
     #argument
-    if sys.argv[1] == '-p' and sys.argv[2]:
-        try:
-            srvport = int(sys.argv[2])
-        except:
-            srvport = 80
+    if len(sys.argv) > 2:
+        if sys.argv[1] == '-p':
+            try:
+                srvport = int(sys.argv[2])
+            except:
+                srvport = 80
     else:
         srvport = 80
 

--- a/app.py
+++ b/app.py
@@ -27,5 +27,15 @@ def valves():
     return render_template('valves.html')
 
 if __name__ == '__main__':  # Script executed directly?
-    app.run(host='0.0.0.0', port=80)  # Launch built-in web server and run this Flask webapp
-    
+    #define port number via cmd-line arguments
+    #checks for -p as first argument, and presence of a number as the second
+    #argument
+    if sys.argv[1] == '-p' and sys.argv[2]:
+        try:
+            srvport = int(sys.argv[2])
+        except:
+            srvport = 80
+    else:
+        srvport = 80
+
+    app.run(host='0.0.0.0', port=srvport)  # Launch built-in web server and run this Flask webapp


### PR DESCRIPTION
added simple argv checker to set port. default port for application is port 80, but can be overridden with -p

default without arguments is that port is set to 80. For testing, "python3 -p X" (with X = to some number) will setup the server on that specific port.